### PR TITLE
Better id extraction + updated test site description

### DIFF
--- a/youtube_dl/extractor/mediaklikk.py
+++ b/youtube_dl/extractor/mediaklikk.py
@@ -8,14 +8,14 @@ import re
 
 class MediaKlikkIE(InfoExtractor):
     # Named regular expression group: (?P<name>...) used for referencing match as 'id'
-    _VALID_URL = r'https?:\/\/(?:www\.)?(?:mediaklikk|m4sport|hirado)\.hu\/.*?videok?\/(?P<id>[^\/]+)\/?'
+    _VALID_URL = r'https?:\/\/(?:www\.)?(?:mediaklikk|m4sport|hirado)\.hu\/.*?videok?.*\/(?P<id>[^\/]+)\/?'
 
     _TEST = {
         'url': 'https://mediaklikk.hu/adal2020/video/2020/03/07/a-dal-donto/',
         'info_dict': {
-            'id': 'kiberma-2020-04-30-i-adas',
+            'id': 'a-dal-donto',
             'ext': 'mp4',
-            'title': 'KiberMa, 2020.04.30-i adás | MédiaKlikk',
+            'title': 'A Dal 2020, Döntő | MédiaKlikk',
             # no thumbnail extractable
         }
     }

--- a/youtube_dl/extractor/mediaklikk.py
+++ b/youtube_dl/extractor/mediaklikk.py
@@ -8,17 +8,36 @@ import re
 
 class MediaKlikkIE(InfoExtractor):
     # Named regular expression group: (?P<name>...) used for referencing match as 'id'
-    _VALID_URL = r'https?:\/\/(?:www\.)?(?:mediaklikk|m4sport|hirado)\.hu\/.*?videok?.*\/(?P<id>[^\/]+)\/?'
+    _VALID_URL = r'https?:\/\/(?:www\.)?(?:mediaklikk|m4sport|hirado)\.hu\/.*\/(?P<id>[^\/]+)\/?'
 
-    _TEST = {
+    _TESTS = [{
         'url': 'https://mediaklikk.hu/adal2020/video/2020/03/07/a-dal-donto/',
+        'md5': 'bae2df47983139d831fef87b40f3ccff',
         'info_dict': {
             'id': 'a-dal-donto',
             'ext': 'mp4',
-            'title': 'A Dal 2020, Döntő | MédiaKlikk',
+            'title': 'A Dal 2020, Döntő',
             # no thumbnail extractable
         }
-    }
+    }, {
+        'url': 'https://m4sport.hu/bl-video/uefa-bajnokok-ligaja-selejtezo-ferencvarosi-tc-gnk-dinamo-zagreb-merkozes/',
+        'md5': '1d03d9ce5156a0f48a8f0856e9190ead',
+        'info_dict': {
+            'id': 'uefa-bajnokok-ligaja-selejtezo-ferencvarosi-tc-gnk-dinamo-zagreb-merkozes',
+            'ext': 'mp4',
+            'title': 'UEFA Bajnokok Ligája selejtező: Ferencvárosi TC - GNK Dinamo Zagreb mérkőzés',
+            # no thumbnail extractable
+        }
+    }, {
+        'url': 'https://hirado.hu/video/2020/09/21/az-operativ-torzs-rendkivuli-sajtotajekoztatoja-2020-szeptember-21',
+        'md5': 'f00b6bd229f60f58ea52b88b91efd239',
+        'info_dict': {
+            'id': 'az-operativ-torzs-rendkivuli-sajtotajekoztatoja-2020-szeptember-21',
+            'ext': 'mp4',
+            'title': 'Az operatív törzs rendkívüli sajtótájékoztatója, 2020. szeptember 21.',
+            # no thumbnail extractable
+        }
+    }]
 
     def _real_extract(self, url):
         mobj = re.match(self._VALID_URL, url)
@@ -42,7 +61,8 @@ class MediaKlikkIE(InfoExtractor):
             info_ret['series'] = info_meta['series']
         info_meta['video'] = info_meta['token']
         del info_meta['token']
-        playerpage = self._download_webpage('https://player.mediaklikk.hu/playernew/player.php', video_id, query=info_meta)
+        playerpage = self._download_webpage('https://player.mediaklikk.hu/playernew/player.php',
+                                            video_id, query=info_meta)
         pattern = r"\"file\": \"(\\/\\/.*playlist\.m3u8)\","
         playlist_url = 'https:' + compat_urllib_parse_unquote(
             self._html_search_regex(pattern, playerpage, 'playlist_url'))\


### PR DESCRIPTION
## Please follow the guide below

- You will be asked some questions, please read them **carefully** and answer honestly
- Put an `x` into all the boxes [ ] relevant to your *pull request* (like that [x])
- Use *Preview* tab to see how your *pull request* will actually look like

---

### Before submitting a *pull request* make sure you have:
- [x] At least skimmed through [adding new extractor tutorial](https://github.com/ytdl-org/youtube-dl#adding-support-for-a-new-site) and [youtube-dl coding conventions](https://github.com/ytdl-org/youtube-dl#youtube-dl-coding-conventions) sections
- [x] [Searched](https://github.com/ytdl-org/youtube-dl/search?q=is%3Apr&type=Issues) the bugtracker for similar pull requests
- [x] Checked the code with [flake8](https://pypi.python.org/pypi/flake8)

### In order to be accepted and merged into youtube-dl each piece of code must be in public domain or released under [Unlicense](http://unlicense.org/). Check one of the following options:
- [ ] I am the original author of this code and I am willing to release it under [Unlicense](http://unlicense.org/)
- [x] I am not the original author of this code but it is in public domain or released under [Unlicense](http://unlicense.org/) (provide reliable evidence)

### What is the purpose of your *pull request*?
- [x] Bug fix
- [x] Improvement
- [ ] New extractor
- [ ] New feature

---

### Description of your *pull request* and other information

The id of the video is better extracted by the new regular expression. For example in the video [https://mediaklikk.hu/adal2020/video/2020/03/07/a-dal-donto](https://mediaklikk.hu/adal2020/video/2020/03/07/a-dal-donto) the detected id used to be `2020` and now it is `a-dal-donto`. Also updated the description of the test video.
